### PR TITLE
Fix multi-line unions

### DIFF
--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -9,6 +9,9 @@ w = "hello world".
 'cons
 w = +w(0:1:0:1:e).
 
+'full focus
+show-exec (@w) w.
+
 'show (literal) contellations
 show { a; b; c }.
 
@@ -36,18 +39,18 @@ show g->test1.
 show g->test2.
 
 'extend rays with a head function symbol
-show exec (+f(X); f(X))[=>+a] end
-show exec (+f(X); f(X))[=>a] end
+show-exec (+f(X); f(X))[=>+a].
+show-exec (+f(X); f(X))[=>a].
 
 'remove head function symbol from a ray
-show exec (+f(X); f(X))[+f=>] end
+show-exec (+f(X); f(X))[+f=>].
 
 'substitutions
-show exec (+f(X))[X=>+a(X)] end
-show exec (+f(X))[+f=>+g] end
+show-exec (+f(X))[X=>+a(X)].
+show-exec (+f(X))[+f=>+g].
 
 'tokens (fillable named empty constellation)
-show exec (#1 #2)[1=>+f(X) X][2=>-f(a)] end
+show-exec (#1 #2)[1=>+f(X) X][2=>-f(a)].
 
 'checkers & typechecking
 checker = galaxy

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -44,13 +44,14 @@ let galaxy_content :=
   | SHARP; ~=SYM;                       <Token>
   | cs=raw_constellation;               { Raw (Const cs) }
   | ~=SYM;                              <Id>
-  | g=galaxy_content; h=galaxy_content; { Union (g, h) }
+  | g=galaxy_content; EOL*;
+    h=galaxy_content; EOL*;             { Union (g, h) }
   | ~=galaxy_content; RARROW; ~=SYM;    <Access>
   | ~=galaxy_content;
     LBRACK; DRARROW; ~=symbol; RBRACK;  <Extend>
   | ~=galaxy_content;
     LBRACK; ~=symbol; DRARROW; RBRACK;  <Reduce>
-  | AT; ~=galaxy_content;               <Focus>
+  | LPAR; AT; ~=galaxy_content; RPAR;   <Focus>
   | ~=galaxy_content; LBRACK; x=VAR;
     DRARROW; r=ray; RBRACK;             <SubstVar>
   | e=galaxy_content; LBRACK; f=symbol;


### PR DESCRIPTION
Fixes #13 

Full focus `@` now has to be surrounded by parentheses as in `(@x)` because of a grammar conflict.