### PR TITLE
Add placeholders in definitions

### DIFF
--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -25,6 +25,9 @@ let program :=
 
 let declaration :=
   | ~=SYM; EQ; EOL*; ~=galaxy_expr; <Def>
+  | PLACEHOLDER; EOL*; EQ; EOL*;
+    g=galaxy_expr;
+    { Def ("_"^(fresh_placeholder ()), g) }
   | SHOW; EOL*; ~=galaxy_expr;      <Show>
   | SHOWEXEC; EOL*; ~=galaxy_expr;  <ShowExec>
   | TRACE; EOL*; ~=galaxy_expr;     <Trace>


### PR DESCRIPTION
It is now possible to write `_ = <some galaxy>`