### PR TITLE
Add plural types

### DIFF
--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -75,3 +75,10 @@ end
 
 1 :: nat [checker].
 1 = +nat(s(0)).
+
+'double typing
+nat2 = { -nat(X) ok }.
+
+2 :: nat [checker].
+2 :: nat2.
+2 = +nat(s(s(0))).

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -23,14 +23,17 @@ let program :=
   | EOL*; d=declaration; EOF;             { [d] }
 
 let declaration :=
-  | ~=SYM; EOL*; EQ; EOL*; ~=galaxy_expr; <Def>
-  | SHOW; EOL*; ~=galaxy_expr;            <Show>
-  | SHOWEXEC; EOL*; ~=galaxy_expr;        <ShowExec>
-  | TRACE; EOL*; ~=galaxy_expr;           <Trace>
-  | RUN; EOL*; ~=galaxy_expr;             <Run>
-  | ~=SYM; CONS; CONS; ~=SYM; EOL*;
-    ~=checker_def; DOT;                   <TypeDef>
-  | x=SYM; CONS; CONS; t=SYM; DOT;        { TypeDef (x, t, None) }
+  | ~=SYM; EOL*; EQ; EOL*; ~=galaxy_expr;   <Def>
+  | SHOW; EOL*; ~=galaxy_expr;              <Show>
+  | SHOWEXEC; EOL*; ~=galaxy_expr;          <ShowExec>
+  | TRACE; EOL*; ~=galaxy_expr;             <Trace>
+  | RUN; EOL*; ~=galaxy_expr;               <Run>
+  | ~=SYM; CONS; CONS;
+    ~=separated_nonempty_list(COMMA, SYM);
+    EOL*; ~=checker_def; DOT;               <TypeDef>
+  | x=SYM; CONS; CONS;
+    ts=separated_nonempty_list(COMMA, SYM);
+    DOT;                                    { TypeDef (x, ts, None) }
 
 let checker_def :=
   | ~=bracks(SYM); <Some>


### PR DESCRIPTION
Use it with

```
c :: t1, t2, ..., tn [checker].
```

or


```
c :: t1, t2, ..., tn.
```

It's the same as

```
c :: t1.
c :: t2.
...
c :: tn.
```

Also allow several declarations of types with different checkers as in:

```
c :: t1 [checker1].
c :: t2 [checker2].
...
c :: tN [checkerN].
```

Closes #73 