### PR TITLE
Add type declarations in galaxies and update galaxies syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It draws inspiration (or try to draw inspiration) from:
 - Smalltalk (for message-passing, object-oriented paradigm and minimalism);
 - Coq (for proof-as-program paradigm and iterative programming with tactics);
 - Scheme/Racket (for minimalism and metaprogramming);
-- Haskell/Ruby (for syntax).
+- Haskell/Ruby/Lua (for syntax).
 
 ## Syntax sample
 

--- a/README.md
+++ b/README.md
@@ -46,11 +46,11 @@ e = +i(e).
 110 = +i(1:1:0:e).
 
 a1 = galaxy
-  initial:
+  initial =
     -i(W) +a(W q0).
-  final:
+  final =
     -a(e q2) accept.
-  transitions:
+  transitions =
     -a(0:W q0) +a(W q0);
     -a(0:W q0) +a(W q1);
     -a(1:W q0) +a(W q0);

--- a/examples/automata.sg
+++ b/examples/automata.sg
@@ -17,11 +17,11 @@ e = +i(e).
 110 = +i(1:1:0:e).
 
 a1 = galaxy
-  initial:
+  initial =
     -i(W) +a(W q0).
-  final:
+  final =
     -a(e q2) accept.
-  transitions:
+  transitions =
     -a(0:W q0) +a(W q0);
     -a(0:W q0) +a(W q1);
     -a(1:W q0) +a(W q0);

--- a/examples/binary4.sg
+++ b/examples/binary4.sg
@@ -1,12 +1,12 @@
 u4 = -b(1 _) -b(2 _) -b(3 _) -b(4 _) ok.
 
 checker = galaxy
-  interaction:
+  interaction =
     process
       #test.
       #tested[b=>+b].
     end
-  expect: { ok }.
+  expect = { ok }.
 end
 
 b1 :: u4 [checker].

--- a/examples/linear_lambda.sg
+++ b/examples/linear_lambda.sg
@@ -13,10 +13,10 @@ show-exec id x_arg linker.
 
 ''' linear types '''
 "a -o a" = galaxy
-  test1:
+  test1 =
     -x(X) +parxy(X); -y(X);
     @-parxy(X) ok.
-  test2:
+  test2 =
     -x(X); -y(X) +parxy(X);
     @-parxy(X) ok.
 end

--- a/examples/mll.sg
+++ b/examples/mll.sg
@@ -1,21 +1,21 @@
 '''test of linear identity'''
 "a -o a" = galaxy
-  testrl:
+  testrl =
     -1(X) -2(X) +c5(X);
     -3(X); -4(X) +c6(X);
     -c5(X) +7(X); -c6(X);
     @-7(X) ok.
-  testrr:
+  testrr =
     -1(X) -2(X) +c5(X);
     -3(X); -4(X) +c6(X);
     -c5(X); +7(X) -c6(X);
     @-7(X) ok.
-  testll:
+  testll =
     -1(X) -2(X) +c5(X);
     -4(X); -3(X) +c6(X);
     -c5(X) +7(X); -c6(X);
     @-7(X) ok.
-  testlr:
+  testlr =
     -1(X) -2(X) +c5(X);
     -4(X); -3(X) +c6(X);
     -c5(X); +7(X) -c6(X);
@@ -33,10 +33,8 @@ id =
 
 '''cut-elimination'''
 ps1 = galaxy
-  vehicle:
-    +7(l:X) +7(r:X); 3(X) +8(l:X); @+8(r:X) 6(X).
-  cuts:
-    -7(X) -8(X).
+  vehicle = +7(l:X) +7(r:X); 3(X) +8(l:X); @+8(r:X) 6(X).
+  cuts = -7(X) -8(X).
 end
 
 show-exec ps1->vehicle ps1->cuts.

--- a/examples/nat.sg
+++ b/examples/nat.sg
@@ -1,8 +1,8 @@
 nat = -nat(0) ok; -nat(s(N)) +nat(N).
 
 fchecker = galaxy
-  interaction: #tested #test.
-  expect: { arg out }.
+  interaction = #tested #test.
+  expect = { arg out }.
 end
 
 "nat -> nat" =

--- a/examples/npda.sg
+++ b/examples/npda.sg
@@ -17,12 +17,12 @@ e = +i(e).
 1110 = +i(1:1:1:0:e).
 
 a1 = galaxy
-  initial:
+  initial =
     -i(W) +a(W e q0).
-  final:
+  final =
     -a(e e q0) accept;
     -a(e e q1) accept.
-  transitions:
+  transitions =
     -a(0:W S q0) +a(W 0:S q0);
     -a(1:W S q0) +a(W 1:S q0);
     -a(W S q0) +a(W S q1);

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -84,3 +84,17 @@ nat2 = { -nat(X) ok }.
 2 = +nat(s(s(0))).
 3 :: nat, nat2.
 3 = +nat(s(s(s(0)))).
+
+'galaxy with type declarations
+show-exec galaxy
+	n1 :: nat [checker].
+  n1: +nat(e).
+	n2 :: nat [checker].
+	n2: +nat(s(s(0))).
+	n3 :: nat [checker].
+	n3: +nat(s(s(0))).
+	n4 :: nat [checker].
+	n4: +nat(s(s(0))).
+	n5 :: nat [checker].
+	n5: +nat(s(s(0))).
+end

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -34,8 +34,8 @@ end
 
 'galaxy definition
 g = galaxy
-  test1: +f(a) ok.
-  test2: +f(b) ok.
+  test1 = +f(a) ok.
+  test2 = +f(b) ok.
 end
 
 'reactive effects
@@ -61,12 +61,12 @@ show-exec (#1 #2)[#1=>+f(X) X][#2=>-f(a)].
 
 'checkers & typechecking
 checker = galaxy
-  interaction: #tested #test.
-  expect: { ok }.
+  interaction = #tested #test.
+  expect = { ok }.
 end
 
 nat = galaxy
-  test:
+  test =
     -nat(0) ok;
     -nat(s(N)) +nat(N).
 end
@@ -88,13 +88,13 @@ nat2 = { -nat(X) ok }.
 'galaxy with type declarations
 show-exec galaxy
 	n1 :: nat [checker].
-  n1: +nat(0).
+  n1 = +nat(0).
 	n2 :: nat [checker].
-	n2: +nat(s(s(0))).
+	n2 = +nat(s(s(0))).
 	n3 :: nat [checker].
-	n3: +nat(s(s(0))).
+	n3 = +nat(s(s(0))).
 	n4 :: nat [checker].
-	n4: +nat(s(s(0))).
+	n4 = +nat(s(s(0))).
 	n5 :: nat [checker].
-	n5: +nat(s(s(0))).
+	n5 = +nat(s(s(0))).
 end

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -88,7 +88,7 @@ nat2 = { -nat(X) ok }.
 'galaxy with type declarations
 show-exec galaxy
 	n1 :: nat [checker].
-  n1: +nat(e).
+  n1: +nat(0).
 	n2 :: nat [checker].
 	n2: +nat(s(s(0))).
 	n3 :: nat [checker].

--- a/guide/en/src/stellogen/galaxies.md
+++ b/guide/en/src/stellogen/galaxies.md
@@ -4,12 +4,12 @@ Constellations can be represented by labelling sub-constellations.
 This is what we call *galaxies*.
 
 Galaxies are defined with blocks `galaxy ... end` containing a series of labels
-`label:` followed by the associated galaxy:
+`label =` followed by the associated galaxy:
 
 ```
 g = galaxy
-  test1: +f(a) ok.
-  test2: +f(b) ok.
+  test1 = +f(a) ok.
+  test2 = +f(b) ok.
 end
 ```
 

--- a/guide/en/src/stellogen/typing.md
+++ b/guide/en/src/stellogen/typing.md
@@ -10,8 +10,8 @@ must be passed:
 
 ```
 t = galaxy
-  test1: @-f(X) ok; -g(X).
-  test2: @-g(X) ok; -f(X).
+  test1 = @-f(X) ok; -g(X).
+  test2 = @-g(X) ok; -f(X).
 end
 ```
 
@@ -40,8 +40,8 @@ For example:
 
 ```
 checker = galaxy
-  interaction: #tested #test.
-  expect: { ok }.
+  interaction = #tested #test.
+  expect = { ok }.
 end
 ```
 
@@ -86,8 +86,8 @@ We can also omit specifying the checker. In this case, the default checker is:
 
 ```
 checker = galaxy
-  interaction: #tested #test.
-  expect: { ok }.
+  interaction = #tested #test.
+  expect = { ok }.
 end
 ```
 

--- a/guide/fr/src/stellogen/galaxies.md
+++ b/guide/fr/src/stellogen/galaxies.md
@@ -4,12 +4,12 @@ Les constellations peuvent être représentées en donnant un nom à des
 sous-constellation les composant. On appelle cela des *galaxies*.
 
 On définit les galaxies avec des blocs `galaxy ... end` contenant une
-série d'étiquettes `label:` suivit de la galaxie associée :
+série d'étiquettes `label =` suivit de la galaxie associée :
 
 ```
 g = galaxy
-  test1: +f(a) ok.
-  test2: +f(b) ok.
+  test1 = +f(a) ok.
+  test2 = +f(b) ok.
 end
 ```
 

--- a/guide/fr/src/stellogen/typing.md
+++ b/guide/fr/src/stellogen/typing.md
@@ -10,8 +10,8 @@ passer :
 
 ```
 t = galaxy
-  test1: @-f(X) ok; -g(X).
-  test2: @-g(X) ok; -f(X).
+  test1 = @-f(X) ok; -g(X).
+  test2 = @-g(X) ok; -f(X).
 end
 ```
 
@@ -40,8 +40,8 @@ Par exemple :
 
 ```
 checker = galaxy
-  interaction: #tested #test.
-  expect: { ok }.
+  interaction = #tested #test.
+  expect = { ok }.
 end
 ```
 
@@ -89,8 +89,8 @@ défaut est :
 
 ```
 checker = galaxy
-  interaction: #tested #test.
-  expect: { ok }.
+  interaction = #tested #test.
+  expect = { ok }.
 end
 ```
 

--- a/src/stellogen/pretty.ml
+++ b/src/stellogen/pretty.ml
@@ -1,8 +1,1 @@
-open Base
-
-let surround first last s = first ^ s ^ last
-
-let rec string_of_list printer sep = function
-  | [] -> ""
-  | [ x ] -> printer x
-  | h :: t -> printer h ^ sep ^ string_of_list printer sep t
+../lsc/pretty.ml

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -133,7 +133,7 @@ let subst_funcs env _from _to =
 let group_galaxy =
   List.fold_left ~init:([], []) ~f:(function types, fields ->
     (function
-      | GTypeDef d -> (d :: types, fields)
+    | GTypeDef d -> (d :: types, fields)
     | GLabelDef (x, g') -> (types, (x, g') :: fields) ) )
 
 let rec typecheck_galaxy env g =
@@ -300,7 +300,7 @@ and string_of_galaxy env = function
     "galaxy\n"
     ^ List.fold_left g ~init:"" ~f:(fun acc -> function
         | GLabelDef (k, v) ->
-          acc ^ "  " ^ k ^ ": "
+          acc ^ "  " ^ k ^ " = "
           ^ (v |> eval_galaxy_expr env |> string_of_galaxy env)
           ^ "\n"
         | GTypeDef (x, ts, None) ->

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -136,8 +136,14 @@ let group_galaxy =
       | GTypeDef d -> (d :: types, fields)
     | GLabelDef (x, g') -> (types, (x, g') :: fields) ) )
 
-let rec typecheck_galaxy _ _ =
-  ()
+let rec typecheck_galaxy env g =
+  let types, fields = group_galaxy g in
+  List.iter types ~f:(fun (x, ts, ck) ->
+    let checker : galaxy_expr =
+      match ck with None -> default_checker | Some xck -> get_obj env xck
+    in
+    let new_env = { types = env.types; objs = fields @ env.objs } in
+    List.iter ts ~f:(fun t -> typecheck new_env x t checker) )
 
 and eval_galaxy_expr (env : env) : galaxy_expr -> galaxy = function
   | Raw (Galaxy g) ->

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -152,12 +152,12 @@ let galaxy_def :=
   | GALAXY; EOL*; ~=galaxy_item+; <>
 
 let galaxy_item :=
-  | ~=SYM; CONS; EOL*; ~=galaxy_content; DOT; EOL*; <GLabelDef>
-  | x=SYM; CONS; EOL*; mcs=non_neutral_start_mcs;
+  | ~=SYM; EQ; EOL*; ~=galaxy_content; DOT; EOL*; <GLabelDef>
+  | x=SYM; EQ; EOL*; mcs=non_neutral_start_mcs;
     DOT; EOL*;
     { GLabelDef (x, Raw (Const mcs)) }
-  | ~=SYM; CONS; EOL*; ~=galaxy_block; END; EOL*;   <GLabelDef>
-  | ~=type_declaration; EOL*;                       <GTypeDef>
+  | ~=SYM; EQ; EOL*; ~=galaxy_block; END; EOL*;   <GLabelDef>
+  | ~=type_declaration; EOL*;                     <GTypeDef>
 
 let galaxy_block :=
   | PROCESS; EOL*;                         { Process [] }
@@ -166,5 +166,5 @@ let galaxy_block :=
   | EXEC; EOL*; mcs=non_neutral_start_mcs; { Exec (Raw (Const mcs)) }
 
 let process_item :=
-  | ~=galaxy_content; DOT; EOL*; <>
+  | ~=galaxy_content; DOT; EOL*;          <>
   | mcs=non_neutral_start_mcs; DOT; EOL*; { Raw (Const mcs) }

--- a/test/behavior/automata.sg
+++ b/test/behavior/automata.sg
@@ -13,11 +13,11 @@ e = +i(e).
 1 = +i(1:e).
 
 a1 = galaxy
-	initial:
+	initial =
 		-i(W) +a(W q0).
-	final:
+	final =
 		-a(e q2) accept.
-	transitions:
+	transitions =
 		-a(0:W q0) +a(W q0);
 		-a(0:W q0) +a(W q1);
 		-a(1:W q0) +a(W q0);
@@ -26,26 +26,26 @@ end
 
 empty = {}.
 
-expect = galaxy expect: {}. end
+expect = galaxy expect = {}. end
 tested :: empty [expect].
 tested = process e. a1. kill. end
 
-expect = galaxy expect: {}. end
+expect = galaxy expect = {}. end
 tested :: empty [expect].
 tested = process 0. a1. kill. end
 
-expect = galaxy expect: {}. end
+expect = galaxy expect = {}. end
 tested :: empty [expect].
 tested = process 1. a1. kill. end
 
-expect = galaxy expect: { accept }. end
+expect = galaxy expect = { accept }. end
 tested :: empty [expect].
 tested = process +i(0:0:0:e). a1. kill. end
 
-expect = galaxy expect: {}. end
+expect = galaxy expect = {}. end
 tested :: empty [expect].
 tested = process +i(0:1:0:e). a1. kill. end
 
-expect = galaxy expect: {}. end
+expect = galaxy expect = {}. end
 tested :: empty [expect].
 tested = process +i(1:1:0:e). a1. kill. end

--- a/test/behavior/prolog.sg
+++ b/test/behavior/prolog.sg
@@ -5,18 +5,18 @@ add =
 
 empty = {}.
 
-expect = galaxy expect: { 0 }. end
+expect = galaxy expect = { 0 }. end
 tested :: empty [expect].
 tested = add (@-add(0 0 R) R).
 
-expect = galaxy expect: { s(0) }. end
+expect = galaxy expect = { s(0) }. end
 tested :: empty [expect].
 tested = add (@-add(s(0) 0 R) R).
 
-expect = galaxy expect: { s(0) }. end
+expect = galaxy expect = { s(0) }. end
 tested :: empty [expect].
 tested = add (@-add(0 s(0) R) R).
 
-expect = galaxy expect: { s(s(s(s(0)))) }. end
+expect = galaxy expect = { s(s(s(s(0)))) }. end
 tested :: empty [expect].
 tested = add (@-add(s(s(0)) s(s(0)) R) R).


### PR DESCRIPTION
Syntax is:
```
galaxy
  c1 :: t1 [checker1].
  c1 = e1.
  ...
  cn :: tn [checkern].
  cn = en.
end
```

Syntax of galaxies use `=` instead of `:` for definition to make it consistent with usual definitions.

Related to #14 