### PR TITLE
Add interfaces for galaxies

### DIFF
--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -88,26 +88,20 @@ nat2 = { -nat(X) ok }.
 
 'galaxy with type declarations
 show galaxy
-	n1 :: nat [checker].
+  n1 :: nat [checker].
   n1 = +nat(0).
-	n2 :: nat [checker].
-	n2 = +nat(s(s(0))).
-	n3 :: nat [checker].
-	n3 = +nat(s(s(0))).
-	n4 :: nat [checker].
-	n4 = +nat(s(s(0))).
-	n5 :: nat [checker].
-	n5 = +nat(s(s(0))).
+  n2 :: nat [checker].
+  n2 = +nat(s(s(0))).
 end
 
 'interfaces
 nat_pair = interface
-	n :: nat [checker].
-	m :: nat [checker].
+  n :: nat [checker].
+  m :: nat [checker].
 end
 
 g_pair :: nat_pair.
 g_pair = galaxy
-	n = +nat(0).
-	m = +nat(0).
+  n = +nat(0).
+  m = +nat(0).
 end

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -37,6 +37,7 @@ g = galaxy
   test1 = +f(a) ok.
   test2 = +f(b) ok.
 end
+show g.
 
 'reactive effects
 run +#print(X); -#print("hello world\n").
@@ -86,7 +87,7 @@ nat2 = { -nat(X) ok }.
 3 = +nat(s(s(s(0)))).
 
 'galaxy with type declarations
-show-exec galaxy
+show galaxy
 	n1 :: nat [checker].
   n1 = +nat(0).
 	n2 :: nat [checker].
@@ -97,4 +98,16 @@ show-exec galaxy
 	n4 = +nat(s(s(0))).
 	n5 :: nat [checker].
 	n5 = +nat(s(s(0))).
+end
+
+'interfaces
+nat_pair = interface
+	n :: nat [checker].
+	m :: nat [checker].
+end
+
+g_pair :: nat_pair.
+g_pair = galaxy
+	n = +nat(0).
+	m = +nat(0).
 end

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -78,7 +78,7 @@ end
 1 :: nat [checker].
 1 = +nat(s(0)).
 
-'double typing
+'plural typing
 nat2 = { -nat(X) ok }.
 2 :: nat [checker].
 2 :: nat2.

--- a/guide/en/src/stellogen/typing.md
+++ b/guide/en/src/stellogen/typing.md
@@ -121,3 +121,25 @@ nat2 = { -nat(X) ok }.
 3 :: nat, nat2.
 3 = +nat(s(s(s(0)))).
 ```
+
+## Interface
+
+It is possible to define interfaces describing a series of identifiers with
+a corresponding type to satisfy.
+
+```
+nat_pair = interface
+	n :: nat [checker].
+	m :: nat [checker].
+end
+```
+
+It is then possible to ask for a galaxy to satisfy that interface.
+
+```
+g_pair :: nat_pair.
+g_pair = galaxy
+	n = +nat(0).
+	m = +nat(0).
+end
+```

--- a/guide/fr/src/stellogen/typing.md
+++ b/guide/fr/src/stellogen/typing.md
@@ -124,3 +124,25 @@ nat2 = { -nat(X) ok }.
 3 :: nat, nat2.
 3 = +nat(s(s(s(0)))).
 ```
+
+## Interfaces
+
+Il est possible de définir des interfaces décrivant une liste d'identifiants
+devant être d'un certain type.
+
+```
+nat_pair = interface
+	n :: nat [checker].
+	m :: nat [checker].
+end
+```
+
+On peut ensuite demander à ce qu'une galaxie respecte cette interface.
+
+```
+g_pair :: nat_pair.
+g_pair = galaxy
+	n = +nat(0).
+	m = +nat(0).
+end
+```

--- a/nvim/syntax/stellogen.vim
+++ b/nvim/syntax/stellogen.vim
@@ -1,6 +1,6 @@
 syn clear
 
-syn keyword sgKeyword show exec trace process end galaxy run
+syn keyword sgKeyword show exec trace process end galaxy run interface
 syn match sgComment "\s*'[^'].*$"
 syn region sgComment start="'''" end="'''" contains=NONE
 syn region sgString start=/\v"/ skip=/\v\\./ end=/\v"/

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -262,9 +262,8 @@ and equal_galaxy env g g' =
   Lsc_ast.equal_mconstellation mcs mcs'
 
 and check_interface env x i =
-  let g = match get_obj env x with
-    | Raw (Galaxy g) -> g
-    | _ -> raise ExpectedGalaxy
+  let g =
+    match get_obj env x with Raw (Galaxy g) -> g | _ -> raise ExpectedGalaxy
   in
   let type_decls = List.map i ~f:(fun t -> GTypeDef t) in
   typecheck_galaxy env (type_decls @ g)
@@ -273,7 +272,9 @@ and typecheck env x t (ck : galaxy_expr) : unit =
   let gtests =
     match get_obj env t |> eval_galaxy_expr env with
     | Const mcs -> [ ("_", Raw (Const mcs)) ]
-    | Interface i -> check_interface env x i; []
+    | Interface i ->
+      check_interface env x i;
+      []
     | Galaxy gtests -> group_galaxy gtests |> snd
   in
   let testing =
@@ -312,27 +313,25 @@ and default_checker =
 
 and string_of_type_declaration (x, ts, ck) =
   match ck with
-  | None ->
-    Printf.sprintf "%s :: %s.\n" x (Pretty.string_of_list Fn.id "," ts)
+  | None -> Printf.sprintf "%s :: %s.\n" x (Pretty.string_of_list Fn.id "," ts)
   | Some xck ->
-    Printf.sprintf "%s :: %s [%s].\n" x
-      (Pretty.string_of_list Fn.id "," ts)
-      xck
+    Printf.sprintf "%s :: %s [%s].\n" x (Pretty.string_of_list Fn.id "," ts) xck
 
 and string_of_galaxy_declaration env = function
   | GLabelDef (k, v) ->
-    Printf.sprintf "  %s = %s\n"
-    k (v |> eval_galaxy_expr env |> string_of_galaxy env)
+    Printf.sprintf "  %s = %s\n" k
+      (v |> eval_galaxy_expr env |> string_of_galaxy env)
   | GTypeDef (x, ts, ck) -> "  " ^ string_of_type_declaration (x, ts, ck)
 
 and string_of_galaxy env g =
   match g with
   | Const mcs -> mcs |> remove_mark_all |> string_of_constellation
-  | Interface i -> Printf.sprintf "interface\n%s\nend"
-    (Pretty.string_of_list string_of_type_declaration "" i)
+  | Interface i ->
+    Printf.sprintf "interface\n%s\nend"
+      (Pretty.string_of_list string_of_type_declaration "" i)
   | Galaxy g ->
     Printf.sprintf "galaxy\n%send"
-    (Pretty.string_of_list (string_of_galaxy_declaration env) "" g)
+      (Pretty.string_of_list (string_of_galaxy_declaration env) "" g)
 
 let rec eval_decl env : declaration -> env = function
   | Def (x, _) when is_reserved x -> raise (ReservedWord x)

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -15,6 +15,7 @@ type type_declaration = ident * ident list * ident option
 type galaxy =
   | Const of marked_constellation
   | Galaxy of galaxy_declaration list
+  | Interface of type_declaration list
 
 and galaxy_declaration =
   | GTypeDef of type_declaration
@@ -43,6 +44,8 @@ let reserved_words = [ "clean"; "kill" ]
 let is_reserved = List.mem reserved_words ~equal:equal_string
 
 exception IllFormedChecker
+
+exception ExpectedGalaxy
 
 exception ReservedWord of ident
 
@@ -85,6 +88,7 @@ let get_type env x =
 
 let rec map_galaxy env ~f = function
   | Const mcs -> Const (f mcs)
+  | Interface i -> Interface i
   | Galaxy g ->
     Galaxy
       (List.map g ~f:(function
@@ -150,10 +154,12 @@ and eval_galaxy_expr (env : env) : galaxy_expr -> galaxy = function
     typecheck_galaxy env g;
     Galaxy g
   | Raw (Const mcs) -> Const mcs
+  | Raw (Interface _) -> Interface []
   | Token _ -> Const []
   | Access (e, x) -> begin
     match eval_galaxy_expr env e with
     | Const _ -> raise (UnknownField x)
+    | Interface _ -> raise (UnknownField x)
     | Galaxy g -> (
       let _, fields = group_galaxy g in
       try
@@ -221,6 +227,7 @@ and eval_galaxy_expr (env : env) : galaxy_expr -> galaxy = function
 
 and galaxy_to_constellation env = function
   | Const mcs -> mcs
+  | Interface _ -> []
   | Galaxy g ->
     let _, fields = group_galaxy g in
     List.fold_left fields ~init:[] ~f:(fun acc (_, v) ->
@@ -254,10 +261,19 @@ and equal_galaxy env g g' =
   let mcs' = galaxy_to_constellation env g' in
   Lsc_ast.equal_mconstellation mcs mcs'
 
+and check_interface env x i =
+  let g = match get_obj env x with
+    | Raw (Galaxy g) -> g
+    | _ -> raise ExpectedGalaxy
+  in
+  let type_decls = List.map i ~f:(fun t -> GTypeDef t) in
+  typecheck_galaxy env (type_decls @ g)
+
 and typecheck env x t (ck : galaxy_expr) : unit =
   let gtests =
     match get_obj env t |> eval_galaxy_expr env with
     | Const mcs -> [ ("_", Raw (Const mcs)) ]
+    | Interface i -> check_interface env x i; []
     | Galaxy gtests -> group_galaxy gtests |> snd
   in
   let testing =
@@ -294,23 +310,29 @@ and default_checker =
            )
        ] )
 
-and string_of_galaxy env = function
+and string_of_type_declaration (x, ts, ck) =
+  match ck with
+  | None ->
+    Printf.sprintf "%s :: %s.\n" x (Pretty.string_of_list Fn.id "," ts)
+  | Some xck ->
+    Printf.sprintf "%s :: %s [%s].\n" x
+      (Pretty.string_of_list Fn.id "," ts)
+      xck
+
+and string_of_galaxy_declaration env = function
+  | GLabelDef (k, v) ->
+    Printf.sprintf "  %s = %s\n"
+    k (v |> eval_galaxy_expr env |> string_of_galaxy env)
+  | GTypeDef (x, ts, ck) -> "  " ^ string_of_type_declaration (x, ts, ck)
+
+and string_of_galaxy env g =
+  match g with
   | Const mcs -> mcs |> remove_mark_all |> string_of_constellation
+  | Interface i -> Printf.sprintf "interface\n%s\nend"
+    (Pretty.string_of_list string_of_type_declaration "" i)
   | Galaxy g ->
-    "galaxy\n"
-    ^ List.fold_left g ~init:"" ~f:(fun acc -> function
-        | GLabelDef (k, v) ->
-          acc ^ "  " ^ k ^ " = "
-          ^ (v |> eval_galaxy_expr env |> string_of_galaxy env)
-          ^ "\n"
-        | GTypeDef (x, ts, None) ->
-          Printf.sprintf "%s  %s :: %s.\n" acc x
-            (Pretty.string_of_list Fn.id "," ts)
-        | GTypeDef (x, ts, Some xck) ->
-          Printf.sprintf "%s  %s :: %s [%s].\n" acc x
-            (Pretty.string_of_list Fn.id "," ts)
-            xck )
-    ^ "end"
+    Printf.sprintf "galaxy\n%send"
+    (Pretty.string_of_list (string_of_galaxy_declaration env) "" g)
 
 let rec eval_decl env : declaration -> env = function
   | Def (x, _) when is_reserved x -> raise (ReservedWord x)
@@ -326,6 +348,9 @@ let rec eval_decl env : declaration -> env = function
              List.iter ts ~f:(fun t -> typecheck env x t (get_obj env xck)) )
     end;
     env
+  | Show (Id x) ->
+    let e = get_obj env x in
+    eval_decl env (Show e)
   | Show (Raw (Galaxy g)) ->
     Galaxy g |> string_of_galaxy env |> Stdlib.print_string;
     Stdlib.print_newline ();

--- a/src/stellogen/sgen_lexer.mll
+++ b/src/stellogen/sgen_lexer.mll
@@ -18,6 +18,7 @@ rule read = parse
   | "end"       { END }
   | "exec"      { EXEC }
   | "run"       { RUN }
+  | "interface" { INTERFACE }
   | "show"      { SHOW }
   | "trace"     { TRACE }
   | "show-exec" { SHOWEXEC }

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -4,6 +4,7 @@ open Sgen_ast
 
 %token SHOW SHOWEXEC
 %token EXEC
+%token INTERFACE
 %token RUN
 %token TRACE
 %token PROCESS
@@ -41,8 +42,12 @@ let galaxy_expr :=
   | ~=raw_galaxy_expr;           <Raw>
 
 let raw_galaxy_expr :=
-  | ~=non_neutral_start_mcs; EOL*; DOT; <Const>
-  | g=galaxy_def; END;                  <Galaxy>
+  | ~=non_neutral_start_mcs; EOL*; DOT;      <Const>
+  | ~=galaxy_def; END;                       <Galaxy>
+  | INTERFACE; EOL*; ~=interface_item+; END; <Interface>
+
+let interface_item :=
+  | ~=type_declaration; EOL*; <>
 
 let raw_galaxy_content :=
   | ~=pars(non_neutral_start_mcs);   <Const>

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -33,7 +33,7 @@ let declaration :=
 
 let type_declaration :=
   | x=SYM; CONS; CONS; ts=separated_list(COMMA, SYM);
-    EOL*; ck=bracks(SYM)?; DOT;
+    EOL*; ck=bracks(SYM)?; EOL*; DOT;
     { (x, ts, ck) }
 
 let galaxy_expr :=
@@ -44,7 +44,7 @@ let galaxy_expr :=
 let raw_galaxy_expr :=
   | ~=non_neutral_start_mcs; EOL*; DOT;      <Const>
   | ~=galaxy_def; END;                       <Galaxy>
-  | INTERFACE; EOL*; ~=interface_item+; END; <Interface>
+  | INTERFACE; EOL*; ~=interface_item*; END; <Interface>
 
 let interface_item :=
   | ~=type_declaration; EOL*; <>
@@ -154,7 +154,7 @@ let raw_constellation :=
   | ~=braces_opt(non_neutral_start_mcs); <>
 
 let galaxy_def :=
-  | GALAXY; EOL*; ~=galaxy_item+; <>
+  | GALAXY; EOL*; ~=galaxy_item*; <>
 
 let galaxy_item :=
   | ~=SYM; EQ; EOL*; ~=galaxy_content; DOT; EOL*; <GLabelDef>


### PR DESCRIPTION
- Add interfaces for galaxies
- Refactoring for display of galaxies

Syntax reference : 

```
'interfaces
nat_pair = interface
	n :: nat [checker].
	m :: nat [checker].
end

g_pair :: nat_pair.
g_pair = galaxy
	n = +nat(0).
	m = +nat(0).
end
```

Closes #11 
Leaves subtyping for #80