### PR TITLE
Remove sensitivity to order in equality

### DIFF
--- a/exercises/solutions/04-boolean.sg
+++ b/exercises/solutions/04-boolean.sg
@@ -9,7 +9,7 @@ not :: not_spec.
 not = +not(0 1); +not(1 0).
 
 'how to print the truth table of NOT ?
-table_not :=: { table_not(1 0); table_not(0 1) }.
+table_not :=: { table_not(0 1); table_not(1 0) }.
 table_not = not {@-not(X Y) table_not(X Y)}.
 
 and_spec = galaxy


### PR DESCRIPTION
We had

```
a; b; c != b; c; a
[a b c] != [b c a]
```

because equality was purely syntactic. Because of that, `expect` field of tests had an unexpected behavior. Equality between constellations now consider constellations as unordered collections.

Could be improved by using `Base.Set`.