### PR TITLE
Linear constellations

### DIFF
--- a/bin/lscrun.ml
+++ b/bin/lscrun.ml
@@ -5,12 +5,13 @@ open Lsc.Lsc_parser
 open Lsc.Lsc_lexer
 open Out_channel
 
-let usage_msg =
-  "exec [-allow-unfinished-computation] [-show-steps] [-show-trace] <filename>"
+let usage_msg = "exec [-linear] [-show-trace] <filename>"
 
 let unfincomp = ref false
 
 let showtrace = ref false
+
+let linear = ref false
 
 let input_file = ref ""
 
@@ -25,6 +26,7 @@ let speclist =
   ; ( "-show-trace"
     , Stdlib.Arg.Set showtrace
     , "Interactively show steps of selection and unification." )
+  ; ("-linear", Stdlib.Arg.Set linear, "Actions which are used are consummed.")
   ]
 
 let () =
@@ -32,7 +34,7 @@ let () =
   let lexbuf = Lexing.from_channel (Stdlib.open_in !input_file) in
   let mcs = constellation_file read lexbuf in
   let result =
-    match exec ~showtrace:!showtrace mcs with
+    match exec ~linear:!linear ~showtrace:!showtrace mcs with
     | Ok result -> result
     | Error e ->
       pp_err_effect e |> Out_channel.output_string Out_channel.stderr;

--- a/examples/mll.sg
+++ b/examples/mll.sg
@@ -39,15 +39,18 @@ end
 
 show-exec #ps1->vehicle #ps1->cuts.
 
-'''
-FIXME : MLL incorrectness
+spec "a * b" =
+  -1(g:X) -2(g:X) +3(g:X);
+  @-3(g:X) ok.
 
+linear = galaxy
+  interaction = linear-exec #tested #test end
+  expect = ok.
+end
+
+'does not typecheck
+'vehicle :: "a * a" [linear].
 vehicle =
   +3(l:X) +3(r:X);
   -3(l:X) +1(g:X);
   -3(r:X) +2(g:X).
-
-test =
-  -1(g:X) -2(g:X) +3(g:X);
-  @-3(g:X) 3(X).
-'''

--- a/nvim/syntax/stellogen.vim
+++ b/nvim/syntax/stellogen.vim
@@ -1,6 +1,6 @@
 syn clear
 
-syn keyword sgKeyword show exec spec trace process end galaxy run interface
+syn keyword sgKeyword show exec spec linear trace process end galaxy run interface
 syn match sgComment "\s*'[^'].*$"
 syn match sgId "#\%(\l\|\d\)\w*"
 syn match sgIdDef "\zs\%(\l\|\d\)\w*\ze\s*="

--- a/src/lsc/lsc_ast.ml
+++ b/src/lsc/lsc_ast.ml
@@ -440,11 +440,13 @@ let search_partners ~linear ~showtrace (selected_ray, other_rays, bans) actions
           (selected_action, other_actions)
           (selected_ray, other_rays, bans)
       in
-      if not @@ List.is_empty res && linear then
+      if (not @@ List.is_empty res) && linear then
         let* next, new_actions = try_actions acc other_actions in
         Ok (res @ next, new_actions)
       else
-        let* next, new_actions = try_actions (selected_action :: acc) other_actions in
+        let* next, new_actions =
+          try_actions (selected_action :: acc) other_actions
+        in
         Ok (res @ next, new_actions)
   in
   try_actions [] actions

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -27,6 +27,7 @@ and galaxy_expr =
   | Access of galaxy_expr * ident
   | Id of ident
   | Exec of galaxy_expr
+  | LinExec of galaxy_expr
   | Union of galaxy_expr * galaxy_expr
   | Subst of galaxy_expr * substitution
   | Focus of galaxy_expr

--- a/src/stellogen/sgen_eval.ml
+++ b/src/stellogen/sgen_eval.ml
@@ -200,7 +200,7 @@ and eval_galaxy_expr ~notyping (env : env) :
     let* eval_e = eval_galaxy_expr ~notyping env e in
     let* mcs = galaxy_to_constellation ~notyping env eval_e in
     begin
-      match exec ~showtrace:false mcs with
+      match exec ~showtrace:true mcs with
       | Ok mcs -> Ok (Const (unmark_all mcs))
       | Error e -> Error (LscError e)
     end

--- a/src/stellogen/sgen_eval.ml
+++ b/src/stellogen/sgen_eval.ml
@@ -31,8 +31,7 @@ let rec map_galaxy env ~f : galaxy -> (galaxy, err) Result.t = function
     in
     Galaxy g' |> Result.return
 
-and map_galaxy_expr env ~f e : (galaxy_expr, err) Result.t =
-  match e with
+and map_galaxy_expr env ~f : galaxy_expr -> (galaxy_expr, err) Result.t = function
   | Raw g ->
     let* map_g = map_galaxy env ~f g in
     Raw map_g |> Result.return
@@ -48,6 +47,9 @@ and map_galaxy_expr env ~f e : (galaxy_expr, err) Result.t =
   | Exec e ->
     let* map_e = map_galaxy_expr env ~f e in
     Exec map_e |> Result.return
+  | LinExec e ->
+    let* map_e = map_galaxy_expr env ~f e in
+    LinExec map_e |> Result.return
   | Union (e, e') ->
     let* map_e = map_galaxy_expr env ~f e in
     let* map_e' = map_galaxy_expr env ~f e' in
@@ -86,6 +88,9 @@ let rec replace_id env (_from : ident) (_to : galaxy_expr) e :
   | Exec e ->
     let* g = replace_id env _from _to e in
     Exec g |> Result.return
+  | LinExec e ->
+    let* g = replace_id env _from _to e in
+    LinExec g |> Result.return
   | Union (e1, e2) ->
     let* g1 = replace_id env _from _to e1 in
     let* g2 = replace_id env _from _to e2 in
@@ -200,7 +205,15 @@ and eval_galaxy_expr ~notyping (env : env) :
     let* eval_e = eval_galaxy_expr ~notyping env e in
     let* mcs = galaxy_to_constellation ~notyping env eval_e in
     begin
-      match exec ~showtrace:false mcs with
+      match exec ~linear:false ~showtrace:false mcs with
+      | Ok mcs -> Ok (Const (unmark_all mcs))
+      | Error e -> Error (LscError e)
+    end
+  | LinExec e ->
+    let* eval_e = eval_galaxy_expr ~notyping env e in
+    let* mcs = galaxy_to_constellation ~notyping env eval_e in
+    begin
+      match exec ~linear:true ~showtrace:false mcs with
       | Ok mcs -> Ok (Const (unmark_all mcs))
       | Error e -> Error (LscError e)
     end

--- a/src/stellogen/sgen_eval.ml
+++ b/src/stellogen/sgen_eval.ml
@@ -31,7 +31,8 @@ let rec map_galaxy env ~f : galaxy -> (galaxy, err) Result.t = function
     in
     Galaxy g' |> Result.return
 
-and map_galaxy_expr env ~f : galaxy_expr -> (galaxy_expr, err) Result.t = function
+and map_galaxy_expr env ~f : galaxy_expr -> (galaxy_expr, err) Result.t =
+  function
   | Raw g ->
     let* map_g = map_galaxy env ~f g in
     Raw map_g |> Result.return

--- a/src/stellogen/sgen_eval.ml
+++ b/src/stellogen/sgen_eval.ml
@@ -200,7 +200,7 @@ and eval_galaxy_expr ~notyping (env : env) :
     let* eval_e = eval_galaxy_expr ~notyping env e in
     let* mcs = galaxy_to_constellation ~notyping env eval_e in
     begin
-      match exec ~showtrace:true mcs with
+      match exec ~showtrace:false mcs with
       | Ok mcs -> Ok (Const (unmark_all mcs))
       | Error e -> Error (LscError e)
     end

--- a/src/stellogen/sgen_lexer.mll
+++ b/src/stellogen/sgen_lexer.mll
@@ -13,46 +13,47 @@ let newline  = '\r' | '\n' | "\r\n"
 
 rule read = parse
   (* Stellogen *)
-  | '{'         { LBRACE }
-  | '}'         { RBRACE }
-  | "end"       { END }
-  | "exec"      { EXEC }
-  | "run"       { RUN }
-  | "interface" { INTERFACE }
-  | "show"      { SHOW }
-  | "spec"      { SPEC }
-  | "trace"     { TRACE }
-  | "show-exec" { SHOWEXEC }
-  | "galaxy"    { GALAXY }
-  | "process"   { PROCESS }
-  | "->"        { RARROW }
-  | "=>"        { DRARROW }
-  | "."         { DOT }
-  | "#"         { SHARP }
-  | "%"         { PERCENT }
-  | '"'         { read_string (Buffer.create 255) lexbuf }
+  | '{'           { LBRACE }
+  | '}'           { RBRACE }
+  | "end"         { END }
+  | "exec"        { EXEC }
+  | "run"         { RUN }
+  | "interface"   { INTERFACE }
+  | "show"        { SHOW }
+  | "spec"        { SPEC }
+  | "trace"       { TRACE }
+  | "linear-exec" { LINEXEC }
+  | "show-exec"   { SHOWEXEC }
+  | "galaxy"      { GALAXY }
+  | "process"     { PROCESS }
+  | "->"          { RARROW }
+  | "=>"          { DRARROW }
+  | "."           { DOT }
+  | "#"           { SHARP }
+  | "%"           { PERCENT }
+  | '"'           { read_string (Buffer.create 255) lexbuf }
   (* Stellar resolution *)
-  | '|'         { BAR }
-  | "!="        { NEQ }
-  | '_'         { PLACEHOLDER }
-  | '['         { LBRACK }
-  | ']'         { RBRACK }
-  | '('         { LPAR }
-  | ')'         { RPAR }
-  | ','         { COMMA }
-  | '@'         { AT }
-  | '+'         { PLUS }
-  | '-'         { MINUS }
-  | '='         { EQ }
-  | ':'         { CONS }
-  | ';'         { SEMICOLON }
-  | var_id      { VAR (Lexing.lexeme lexbuf) }
-  | ident       { SYM (Lexing.lexeme lexbuf) }
+  | '|'     { BAR }
+  | "!="    { NEQ }
+  | '_'     { PLACEHOLDER }
+  | '['     { LBRACK }
+  | ']'     { RBRACK }
+  | '('     { LPAR }
+  | ')'     { RPAR }
+  | ','     { COMMA }
+  | '@'     { AT }
+  | '+'     { PLUS }
+  | '-'     { MINUS }
+  | '='     { EQ }
+  | ':'     { CONS }
+  | ';'     { SEMICOLON }
+  | var_id  { VAR (Lexing.lexeme lexbuf) }
+  | ident   { SYM (Lexing.lexeme lexbuf) }
   (* Common *)
-  | '\''        { comment lexbuf }
-  | "'''"       { comments lexbuf }
-  | space       { read lexbuf }
-  | newline     {
+  | '\''     { comment lexbuf }
+  | "'''"    { comments lexbuf }
+  | space    { read lexbuf }
+  | newline  {
     let pos = lexbuf.lex_curr_p in
     lexbuf.lex_curr_p <- {
       lexbuf.lex_curr_p with

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -9,6 +9,7 @@ open Sgen_ast
 %token SPEC
 %token TRACE
 %token SHARP
+%token LINEXEC
 %token PROCESS
 %token GALAXY
 %token RARROW DRARROW
@@ -95,6 +96,10 @@ let galaxy_block :=
     <Exec>
   | EXEC; EOL*; mcs=marked_constellation; END; EXEC?;
     { Exec (Raw (Const mcs)) }
+  | LINEXEC; EOL*; ~=galaxy_content; END; LINEXEC?;
+    <LinExec>
+  | LINEXEC; EOL*; mcs=marked_constellation; END; LINEXEC?;
+    { LinExec (Raw (Const mcs)) }
 
 let process_item :=
   | ~=galaxy_content; DOT; EOL*;    <>

--- a/test/behavior/automata.sg
+++ b/test/behavior/automata.sg
@@ -26,26 +26,20 @@ end
 
 empty = {}.
 
-expect = galaxy expect = {}. end
-tested :: empty [expect].
+tested :=: {}.
 tested = process #e. #a1. #kill. end
 
-expect = galaxy expect = {}. end
-tested :: empty [expect].
+tested :=: {}.
 tested = process #0. #a1. #kill. end
 
-expect = galaxy expect = {}. end
-tested :: empty [expect].
+tested :=: {}.
 tested = process #1. #a1. #kill. end
 
-expect = galaxy expect = { accept }. end
-tested :: empty [expect].
+tested :=: accept.
 tested = process +i(0:0:0:e). #a1. #kill. end
 
-expect = galaxy expect = {}. end
-tested :: empty [expect].
+tested :=: {}.
 tested = process +i(0:1:0:e). #a1. #kill. end
 
-expect = galaxy expect = {}. end
-tested :: empty [expect].
+tested :=: {}.
 tested = process +i(1:1:0:e). #a1. #kill. end

--- a/test/behavior/linear.sg
+++ b/test/behavior/linear.sg
@@ -1,0 +1,14 @@
+1 = +nat(s(0)).
+2 = +nat(s(s(0))).
+3 = +nat(s(s(s(0)))).
+
+nat = -nat(s(X)) +nat(X).
+
+tested :=: +nat(0).
+tested = linear-exec #1 #nat end
+
+tested :=: +nat(s(0)).
+tested = linear-exec #2 #nat end
+
+tested :=: +nat(s(s(0))).
+tested = linear-exec #3 #nat end

--- a/test/behavior/prolog.sg
+++ b/test/behavior/prolog.sg
@@ -5,18 +5,14 @@ add =
 
 empty = {}.
 
-expect = galaxy expect = 0. end
-tested :: empty [expect].
+tested :=: 0.
 tested = #add (@-add(0 0 R) R).
 
-expect = galaxy expect = s(0). end
-tested :: empty [expect].
+tested :=: s(0).
 tested = #add (@-add(s(0) 0 R) R).
 
-expect = galaxy expect = s(0). end
-tested :: empty [expect].
+tested :=: s(0).
 tested = #add (@-add(0 s(0) R) R).
 
-expect = galaxy expect = s(s(s(s(0)))). end
-tested :: empty [expect].
+tested :=: s(s(s(s(0)))).
 tested = #add (@-add(s(s(0)) s(s(0)) R) R).


### PR DESCRIPTION
Closes issue #44 

Uses linearity (consumption of used actions) instead of acyclicity check. Allows finite checking for MLL types.