### PR TITLE
Improve syntax

### DIFF
--- a/examples/automata.sg
+++ b/examples/automata.sg
@@ -31,7 +31,7 @@ a1 = galaxy
     -a(0:W q1) +a(W q2).
 end
 
-show process #e.   #a1. #kill. end
-show process #000. #a1. #kill. end
-show process #010. #a1. #kill. end
-show process #110. #a1. #kill. end
+show process #e.   #a1. &kill. end
+show process #000. #a1. &kill. end
+show process #010. #a1. &kill. end
+show process #110. #a1. &kill. end

--- a/examples/binary4.sg
+++ b/examples/binary4.sg
@@ -34,7 +34,7 @@ show-exec process
   #b1[b=>+b1].
   #and[arg=>1]. #and[arg=>2]. #and[arg=>3]. #and[arg=>4].
   #b2[b=>+b2].
-  #kill.
+  &kill.
 end
 
 'logical OR
@@ -42,7 +42,7 @@ show-exec process
   #b1[b=>+b1].
   #or[arg=>1]. #or[arg=>2]. #or[arg=>3]. #or[arg=>4].
   #b2[b=>+b2].
-  #kill.
+  &kill.
 end
 
 'logical XOR
@@ -50,5 +50,5 @@ show-exec process
   #b1[b=>+b1].
   #xor[arg=>1]. #xor[arg=>2]. #xor[arg=>3]. #xor[arg=>4].
   #b2[b=>+b2].
-  #kill.
+  &kill.
 end

--- a/examples/circuits.sg
+++ b/examples/circuits.sg
@@ -21,7 +21,7 @@ show-exec process
   'output
     -c4(R) R.
     #semantics.
-    'kill.
+  '&kill.
 end
 
 show-exec process
@@ -37,5 +37,5 @@ show-exec process
     -c4(R) R.
   'apply semantics
     #semantics.
-    'kill.
+  '&kill.
 end

--- a/examples/mall.sg
+++ b/examples/mall.sg
@@ -8,5 +8,5 @@ cut = -5(X) -3(X).
 show-exec process
   #with.
   #plus #cut.
-  #kill.
+  &kill.
 end

--- a/examples/npda.sg
+++ b/examples/npda.sg
@@ -30,7 +30,7 @@ a1 = galaxy
     -a(1:W 1:S q1) +a(W S q1).
 end
 
-show process #e.    #a1. #kill. end
-show process #0000. #a1. #kill. end
-show process #0110. #a1. #kill. end
-show process #1110. #a1. #kill. end
+show process #e.    #a1. &kill. end
+show process #0000. #a1. &kill. end
+show process #0110. #a1. &kill. end
+show process #1110. #a1. &kill. end

--- a/examples/prolog.sg
+++ b/examples/prolog.sg
@@ -25,5 +25,5 @@ query =
 show-exec process
   #query.
   #graph #composition.
-  #kill.
+  &kill.
 end

--- a/examples/stack.sg
+++ b/examples/stack.sg
@@ -16,5 +16,5 @@ show-exec process
 
   -save(C) save(C).
   'kill remaining polarized stars
-  #kill.
+  &kill.
 end

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -81,7 +81,7 @@ nat2 = -nat(X) ok.
 2 :: nat.
 2 :: nat2.
 2 = +nat(s(s(0))).
-3 :: nat, nat2.
+3 :: nat; nat2.
 3 = +nat(s(s(s(0)))).
 
 'galaxy with type declarations

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -106,18 +106,6 @@ end
 'import file
 'use examples->automata.
 
-'proof
-theorem x : nat =
-proof
-  0.
-end
-
-'proof lemma and end proof
-lemma y : nat =
-proof
-  0.
-end proof
-
 'complex identifiers
 f(a b) = function(a b).
 show #f(a b).

--- a/examples/syntax.sg
+++ b/examples/syntax.sg
@@ -40,7 +40,7 @@ end
 show #g.
 
 'reactive effects
-run +%print(X); -%print("hello world\n").
+run +&print(X); -&print("hello world\n").
 
 'access to field of a galaxy
 show #g->test1.
@@ -83,6 +83,8 @@ nat2 = -nat(X) ok.
 2 = +nat(s(s(0))).
 3 :: nat; nat2.
 3 = +nat(s(s(s(0)))).
+4 :: nat [checker]; nat2 [checker].
+4 = +nat(s(s(s(s(0))))).
 
 'galaxy with type declarations
 show galaxy

--- a/examples/turing.sg
+++ b/examples/turing.sg
@@ -32,11 +32,11 @@ mt = galaxy
     -m(qr L C R) reject.
 end
 
-show process +i(a:e:e).       #mt. #kill. end
-show process +i(b:e:e).       #mt. #kill. end
-show process +i(a:b:b:e:e).   #mt. #kill. end
-show process +i(e:e).         #mt. #kill. end
-show process +i(a:b:e:e).     #mt. #kill. end
-show process +i(a:a:b:b:e:e). #mt. #kill. end
-show process +i(a:b:b:a:e:e). #mt. #kill. end
-show process +i(a:b:a:b:e:e). #mt. #kill. end
+show process +i(a:e:e).       #mt. &kill. end
+show process +i(b:e:e).       #mt. &kill. end
+show process +i(a:b:b:e:e).   #mt. &kill. end
+show process +i(e:e).         #mt. &kill. end
+show process +i(a:b:e:e).     #mt. &kill. end
+show process +i(a:a:b:b:e:e). #mt. &kill. end
+show process +i(a:b:b:a:e:e). #mt. &kill. end
+show process +i(a:b:a:b:e:e). #mt. &kill. end

--- a/src/common/common_parser.mly
+++ b/src/common/common_parser.mly
@@ -2,8 +2,8 @@
 %token EOF
 %token AT
 %token DOT
-%token PERCENT
 %token EOL
+%token AMP
 %token LBRACK RBRACK
 %token LBRACE RBRACE
 %token LPAR RPAR

--- a/src/lsc/lsc_lexer.mll
+++ b/src/lsc/lsc_lexer.mll
@@ -20,7 +20,6 @@ rule read = parse
   | ']'      { RBRACK }
   | '('      { LPAR }
   | ')'      { RPAR }
-  | '!'      { BANG }
   | ','      { COMMA }
   | '@'      { AT }
   | '%'      { PERCENT }

--- a/src/lsc/lsc_lexer.mll
+++ b/src/lsc/lsc_lexer.mll
@@ -22,7 +22,7 @@ rule read = parse
   | ')'      { RPAR }
   | ','      { COMMA }
   | '@'      { AT }
-  | '%'      { PERCENT }
+  | '&'      { AMP }
   | '+'      { PLUS }
   | '-'      { MINUS }
   | ':'      { CONS }

--- a/src/lsc/lsc_parser.mly
+++ b/src/lsc/lsc_parser.mly
@@ -45,10 +45,10 @@ let ban :=
   | r1=ray; CONS; r2=ray;  { Incomp (r1, r2) }
 
 %public let symbol :=
-  | p=polarity; PERCENT; f = SYM; { noisy (p, f) }
-  | p=polarity; PERCENT; PRINT;   { noisy (p, "print") }
-  | p=polarity; f = SYM;          { muted (p, f) }
-  | f=SYM; { muted (Null, f) }
+  | p=polarity; AMP; f = SYM; { noisy (p, f) }
+  | p=polarity; AMP; PRINT;   { noisy (p, "print") }
+  | p=polarity; f = SYM;      { muted (p, f) }
+  | f=SYM;                    { muted (Null, f) }
 
 let polarity :=
   | PLUS;  { Pos }

--- a/src/lsc/lsc_parser.mly
+++ b/src/lsc/lsc_parser.mly
@@ -4,7 +4,6 @@ open Lsc_ast
 
 %token BAR
 %token NEQ
-%token BANG
 %token COMMA
 %token <string> VAR
 %token <string> SYM

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -31,6 +31,8 @@ and galaxy_expr =
   | Union of galaxy_expr * galaxy_expr
   | Subst of galaxy_expr * substitution
   | Focus of galaxy_expr
+  | Clean of galaxy_expr
+  | Kill of galaxy_expr
   | Process of galaxy_expr list
 
 and substitution =

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -10,7 +10,7 @@ type idfunc = polarity * string
 type ray_prefix = StellarRays.fmark * idfunc
 
 type type_declaration =
-  | TDef of ident * ident list * ident option
+  | TDef of ident * (ident * ident option) list
   | TExp of ident * galaxy_expr
 
 and galaxy =
@@ -46,7 +46,7 @@ let is_reserved = List.mem reserved_words ~equal:equal_ray
 
 type env =
   { objs : (ident * galaxy_expr) list
-  ; types : (ident * (ident list * ident option)) list
+  ; types : (ident * (ident * ident option) list) list
   }
 
 let expect (g : galaxy_expr) : galaxy_expr =
@@ -58,7 +58,7 @@ let expect (g : galaxy_expr) : galaxy_expr =
 
 let initial_env =
   { objs = [ (const "^empty", Raw (Const [])) ]
-  ; types = [ (const "^empty", ([ const "^empty" ], None)) ]
+  ; types = [ (const "^empty", [ (const "^empty", None) ]) ]
   }
 
 type declaration =

--- a/src/stellogen/sgen_ast.ml
+++ b/src/stellogen/sgen_ast.ml
@@ -69,6 +69,5 @@ type declaration =
   | Run of galaxy_expr
   | TypeDef of type_declaration
   | Use of ident list
-  | ProofDef of ident * ident list * ident option * galaxy_expr
 
 type program = declaration list

--- a/src/stellogen/sgen_eval.ml
+++ b/src/stellogen/sgen_eval.ml
@@ -48,6 +48,12 @@ and map_galaxy_expr env ~f : galaxy_expr -> (galaxy_expr, err) Result.t =
   | Exec e ->
     let* map_e = map_galaxy_expr env ~f e in
     Exec map_e |> Result.return
+  | Kill e ->
+    let* map_e = map_galaxy_expr env ~f e in
+    Kill map_e |> Result.return
+  | Clean e ->
+    let* map_e = map_galaxy_expr env ~f e in
+    Clean map_e |> Result.return
   | LinExec e ->
     let* map_e = map_galaxy_expr env ~f e in
     LinExec map_e |> Result.return
@@ -89,6 +95,12 @@ let rec replace_id env (_from : ident) (_to : galaxy_expr) e :
   | Exec e ->
     let* g = replace_id env _from _to e in
     Exec g |> Result.return
+  | Kill e ->
+    let* g = replace_id env _from _to e in
+    Kill g |> Result.return
+  | Clean e ->
+    let* g = replace_id env _from _to e in
+    Clean g |> Result.return
   | LinExec e ->
     let* g = replace_id env _from _to e in
     LinExec g |> Result.return
@@ -225,6 +237,14 @@ and eval_galaxy_expr ~notyping (env : env) :
     let* eval_e = eval_galaxy_expr ~notyping env e in
     let* mcs = galaxy_to_constellation ~notyping env eval_e in
     Const (mcs |> remove_mark_all |> focus) |> Result.return
+  | Kill e ->
+    let* eval_e = eval_galaxy_expr ~notyping env e in
+    let* mcs = galaxy_to_constellation ~notyping env eval_e in
+    Const (mcs |> remove_mark_all |> kill |> focus) |> Result.return
+  | Clean e ->
+    let* eval_e = eval_galaxy_expr ~notyping env e in
+    let* mcs = galaxy_to_constellation ~notyping env eval_e in
+    Const (mcs |> remove_mark_all |> clean |> focus) |> Result.return
   | Process [] -> Ok (Const [])
   | Process (h :: t) ->
     let* eval_e = eval_galaxy_expr ~notyping env h in

--- a/src/stellogen/sgen_eval.ml
+++ b/src/stellogen/sgen_eval.ml
@@ -483,10 +483,6 @@ let rec eval_decl ~typecheckonly ~notyping env :
       { objs = add_obj env (const "^expect") (expect mcs)
       ; types = add_type env x ([ const "^empty" ], Some (const "^expect"))
       }
-  | ProofDef (x, ts, ck, g) ->
-    eval_decl ~typecheckonly ~notyping
-      { objs = add_obj env x g; types = add_type env x (ts, ck) }
-      (Def (x, g))
   | Use path ->
     let path = List.map path ~f:string_of_ray in
     let formatted_filename = String.concat ~sep:"/" path ^ ".sg" in

--- a/src/stellogen/sgen_lexer.mll
+++ b/src/stellogen/sgen_lexer.mll
@@ -21,6 +21,8 @@ rule read = parse
   | "interface"   { INTERFACE }
   | "show"        { SHOW }
   | "spec"        { SPEC }
+  | "kill"        { KILL }
+  | "clean"       { CLEAN }
   | "use"         { USE }
   | "trace"       { TRACE }
   | "linear-exec" { LINEXEC }
@@ -31,7 +33,7 @@ rule read = parse
   | "=>"          { DRARROW }
   | "."           { DOT }
   | "#"           { SHARP }
-  | "%"           { PERCENT }
+  | "&"           { AMP }
   | '"'           { read_string (Buffer.create 255) lexbuf }
   (* Stellar resolution *)
   | '|'     { BAR }

--- a/src/stellogen/sgen_lexer.mll
+++ b/src/stellogen/sgen_lexer.mll
@@ -27,9 +27,6 @@ rule read = parse
   | "show-exec"   { SHOWEXEC }
   | "galaxy"      { GALAXY }
   | "process"     { PROCESS }
-  | "proof"       { PROOF }
-  | "theorem"     { THEOREM }
-  | "lemma"       { LEMMA }
   | "->"          { RARROW }
   | "=>"          { DRARROW }
   | "."           { DOT }
@@ -44,7 +41,6 @@ rule read = parse
   | ']'     { RBRACK }
   | '('     { LPAR }
   | ')'     { RPAR }
-  | '!'     { BANG }
   | ','     { COMMA }
   | '@'     { AT }
   | '+'     { PLUS }

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -15,7 +15,6 @@ open Sgen_ast
 %token RARROW DRARROW
 %token EQ
 %token END
-%token PROOF LEMMA THEOREM
 
 %start <Sgen_ast.program> program
 %start <Sgen_ast.declaration> declaration
@@ -38,15 +37,8 @@ let declaration :=
   | RUN; EOL*; ~=galaxy_expr;                     <Run>
   | ~=type_declaration;                           <TypeDef>
   | USE; ~=separated_list(RARROW, ident); DOT;    <Use>
-  | proof_spec; x=ident; CONS; ts=separated_list(COMMA, ident);
-    EOL*; ck=bracks(ident)?; EOL*; EQ; EOL*; g=galaxy_expr;
-    { ProofDef (x, ts, ck, g) }
   | INTERFACE; EOL*; x=ident; EOL*; i=interface_item*; END; INTERFACE?;
     { Def (x, Raw (Interface i)) }
-
-let proof_spec :=
-  | THEOREM; EOL*; <>
-  | LEMMA; EOL*; <>
 
 let type_declaration :=
   | x=ident; CONS; CONS; ts=separated_list(COMMA, ident);
@@ -71,8 +63,6 @@ let delimited_raw_galaxy :=
   | ~=braces(marked_constellation); <Const>
 
 let prefixed_id := SHARP; ~=ident; <Id>
-
-let naked_id := ~=ident; <Id>
 
 let galaxy_content :=
   | ~=pars(galaxy_content);                    <>
@@ -126,14 +116,8 @@ let galaxy_item :=
 
 let process :=
   | PROCESS; EOL*; END; PROCESS?;                   { Process [] }
-  | PROOF; EOL*; END; PROOF?;                       { Process [] }
   | PROCESS; EOL*; ~=process_item+; END; PROCESS?;  <Process>
-  | PROOF; EOL*; ~=proof_content+; END; PROOF?;     <Process>
 
 let process_item :=
   | ~=galaxy_content; DOT; EOL*;     <>
   | ~=undelimited_raw_galaxy; EOL*;  <Raw>
-
-let proof_content :=
-  | ~=delimited_raw_galaxy; DOT; EOL*; <Raw>
-  | ~=naked_id; DOT; EOL*;             <>

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -41,17 +41,19 @@ let declaration :=
     { Def (x, Raw (Interface i)) }
 
 let type_declaration :=
-  | x=ident; CONS; CONS; ts=separated_list(COMMA, ident);
-    EOL*; ck=bracks(ident)?; EOL*; DOT;                   { TDef (x, ts, ck) }
-  | x=ident; CONS; EQ; CONS; EOL*; g=galaxy_expr;         { TExp (x, g) }
+  | x=ident; CONS; CONS; ts=separated_list(SEMICOLON, type_expr); EOL*; DOT;
+    { TDef (x, ts) }
+  | x=ident; CONS; EQ; CONS; EOL*; g=galaxy_expr;
+    { TExp (x, g) }
+
+let type_expr := ~=ident; ~=bracks(ident)?; EOL*; <>
 
 let galaxy_expr :=
   | ~=galaxy_content; EOL*; DOT; <>
   | ~=process;                   <>
   | ~=undelimited_raw_galaxy;    <Raw>
 
-let interface_item :=
-  | ~=type_declaration; EOL*; <>
+let interface_item := ~=type_declaration; EOL*; <>
 
 let undelimited_raw_galaxy :=
   | ~=marked_constellation; EOL*; DOT;                <Const>

--- a/src/stellogen/sgen_parser.mly
+++ b/src/stellogen/sgen_parser.mly
@@ -9,6 +9,7 @@ open Sgen_ast
 %token SPEC
 %token TRACE
 %token SHARP
+%token KILL CLEAN
 %token EXEC LINEXEC
 %token PROCESS
 %token GALAXY
@@ -88,10 +89,18 @@ let galaxy_block :=
     <Exec>
   | LINEXEC; EOL*; ~=galaxy_content; EOL*; END; LINEXEC?;
     <LinExec>
+  | KILL; EOL*; ~=galaxy_content; EOL*; END; KILL?;
+    <Kill>
+  | CLEAN; EOL*; ~=galaxy_content; EOL*; END; CLEAN?;
+    <Clean>
   | EXEC; EOL*; mcs=marked_constellation; EOL*; END; EXEC?;
     { Exec (Raw (Const mcs)) }
   | LINEXEC; EOL*; mcs=marked_constellation; EOL*; END; LINEXEC?;
     { LinExec (Raw (Const mcs)) }
+  | KILL; EOL*; mcs=marked_constellation; EOL*; END; KILL?;
+    { Kill (Raw (Const mcs)) }
+  | CLEAN; EOL*; mcs=marked_constellation; EOL*; END; CLEAN?;
+    { Clean (Raw (Const mcs)) }
 
 let galaxy_access :=
   | SHARP; x=ident; RARROW; y=ident;  { Access (Id x, y) }
@@ -123,3 +132,5 @@ let process :=
 let process_item :=
   | ~=galaxy_content; DOT; EOL*;     <>
   | ~=undelimited_raw_galaxy; EOL*;  <Raw>
+  | AMP; KILL; DOT; EOL*;            { Id (const "kill") }
+  | AMP; CLEAN; DOT; EOL*;           { Id (const "clean") }

--- a/test/behavior/automata.sg
+++ b/test/behavior/automata.sg
@@ -27,19 +27,19 @@ end
 empty = {}.
 
 tested :=: {}.
-tested = process #e. #a1. #kill. end
+tested = process #e. #a1. &kill. end
 
 tested :=: {}.
-tested = process #0. #a1. #kill. end
+tested = process #0. #a1. &kill. end
 
 tested :=: {}.
-tested = process #1. #a1. #kill. end
+tested = process #1. #a1. &kill. end
 
 tested :=: accept.
-tested = process +i(0:0:0:e). #a1. #kill. end
+tested = process +i(0:0:0:e). #a1. &kill. end
 
 tested :=: {}.
-tested = process +i(0:1:0:e). #a1. #kill. end
+tested = process +i(0:1:0:e). #a1. &kill. end
 
 tested :=: {}.
-tested = process +i(1:1:0:e). #a1. #kill. end
+tested = process +i(1:1:0:e). #a1. &kill. end

--- a/test/syntax/definitions.sg
+++ b/test/syntax/definitions.sg
@@ -64,6 +64,11 @@ x = +f(X) |
   | X!=Y Y!=X X!=g(Y) g(X)!=Y.
 '''
 
+'incomp
+x = +f(X) | a:b; +f(Y) | a:c.
+x = +f(X) | X!=Y a:b X!=Y; +f(Y) | X!=Y a:c X!=Y.
+x = +f(X) | a:b a:b a:b; +f(Y) | a:c a:c a:c.
+
 'with EOL
 '''FIX ME
 x


### PR DESCRIPTION
- Remove proof definition syntax (use as DSL instead)
- Each types of a type list can specify a checker
- Use `&` instead of `%` for primitives
- Add `kill` and `clean` blocks