### PR TITLE
Add support for reading files

### DIFF
--- a/bin/sgen.ml
+++ b/bin/sgen.ml
@@ -16,7 +16,7 @@ let run input_file =
   match Expr.program_of_expr preprocessed with
   | Ok program ->
     let (_ : (Sgen_ast.env, Sgen_ast.err) Result.t) =
-      Sgen_eval.eval_program program
+      Sgen_eval.eval_program_with_file input_file program
     in
     ()
   | Error (expr_error, loc) -> (
@@ -34,6 +34,7 @@ let trace input_file =
     let initial_env =
       { Sgen_ast.objs =
           (Lsc_ast.const "__trace__", trace_marker) :: Sgen_ast.initial_env.objs
+      ; source_file = Some input_file
       }
     in
     let (_ : (Sgen_ast.env, Sgen_ast.err) Result.t) =

--- a/src/expr.ml
+++ b/src/expr.ml
@@ -627,6 +627,9 @@ let rec sgen_expr_of_expr expr : (sgen_expr, expr_err) Result.t =
   | List [ { content = Symbol "use"; _ }; path ] ->
     let* path_ray = ray_of_expr path.content in
     Use path_ray |> Result.return
+  | List [ { content = Symbol "load-file"; _ }; path ] ->
+    let* path_ray = ray_of_expr path.content in
+    LoadFile path_ray |> Result.return
   | _ ->
     (* Everything else is a raw term *)
     let* ray = ray_of_expr expr in

--- a/src/lsc_pretty.ml
+++ b/src/lsc_pretty.ml
@@ -13,6 +13,9 @@ let string_of_var (x, index_opt) =
 let rec string_of_ray = function
   | Var var -> string_of_var var
   | Func (pf, []) -> string_of_polsym pf
+  | Func ((Null, "%string"), [ Func ((Null, s), []) ]) ->
+    (* Pretty-print strings as "..." *)
+    Printf.sprintf "\"%s\"" s
   | Func ((Null, "%group"), terms) ->
     (* Pretty-print constellation groups as {...} *)
     if List.is_empty terms then "{}"

--- a/src/sgen_ast.ml
+++ b/src/sgen_ast.ml
@@ -25,6 +25,7 @@ type sgen_expr =
   | Expect of sgen_expr * sgen_expr * ident * source_location option
   | Match of sgen_expr * sgen_expr * ident * source_location option
   | Use of ident
+  | LoadFile of ident
 
 type err =
   | ExpectError of
@@ -42,8 +43,11 @@ type err =
   | UnknownID of string * source_location option
   | ExprError of expr_err * source_location option
 
-type env = { objs : (ident * sgen_expr) list }
+type env =
+  { objs : (ident * sgen_expr) list
+  ; source_file : string option
+  }
 
-let initial_env = { objs = [] }
+let initial_env = { objs = []; source_file = None }
 
 type program = sgen_expr list

--- a/test/examples.t
+++ b/test/examples.t
@@ -70,7 +70,7 @@ Syntax reference:
   $ sgen run ../examples/syntax.sg
   a
   { [c] [b] [a] }
-  (%string hello world)
+  "hello world"
   (function a b)
   { [(-f X) (-f Y) (r X Y) || (!= X Y)] [(+f b)] [(+f a)] }
   { [(r b a) || (!= b a)] [(r a b) || (!= a b)] }


### PR DESCRIPTION
Add `load-file` macro to read a file in the same directory as the program being executed. Example of use:

```
(show (load-file "test.txt"))
```

if `test.txt` is a file in the same directory as the program and if it contains `abc` then the program will show `["a" "b" "c"]`.

Close #165 