### PR TITLE
Fix nix configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,10 +108,15 @@ dune build
 
 **Option D: Build with Nix**
 ```bash
-nix develop
-dune build
-```
+nix build
 
+```
+If you wish, you can explicitly specify the derivation, like `nix build .#default`:
+- `default`/`stellogen`: The default binary
+- `stellogen-minimal`: Minimal version without documentation and JavaScript
+- `stellogen-web`: JavaScript version
+- `playground`: Playground files you can host with e.g. `python3 -m http.server` or directly with `nix run .#playground`
+- `docs`: Documentation
 ### 2. Run Your First Program
 
 Assuming the executable is named `sgen` and that it is in your PATH:

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,81 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1782175435,
+        "narHash": "sha256-EMzXKmnOtBQ2MnvpiNOm7E+kOMvdPrIKaeg52Tip2Uk=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "89570f24e97e614aa34aa9ab1c927b6578a43775",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -2,65 +2,119 @@
   description = "stellogen";
 
   inputs = {
-    # Remark: when adding inputs here, don't forget to also add them in the
-    # arguments to `outputs` below!
-    flake-utils.url = "github:numtide/flake-utils";
-    nixpkgs.url = "nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    systems.url = "github:nix-systems/default";
+    flake-parts = {
+      url = "github:hercules-ci/flake-parts";
+      inputs.nixpkgs-lib.follows = "nixpkgs";
+    };
+    flake-compat = {
+      url = "github:NixOS/flake-compat";
+      flake = false;
+    };
   };
 
-  # Remark: keep the list of outputs in sync with the list of inputs above
-  # (see above remark)
-  outputs = { self, flake-utils, nixpkgs}:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; };
-        ocamlPackages = pkgs.ocamlPackages;
-        easy_logging = ocamlPackages.buildDunePackage rec {
-          pname = "easy_logging";
-          version = "0.8.2";
-          src = pkgs.fetchFromGitHub {
-            owner = "sapristi";
-            repo = "easy_logging";
-            rev = "v${version}";
-            sha256 = "sha256-Xy6Rfef7r2K8DTok7AYa/9m3ZEV07LlUeMQSRayLBco=";
+  outputs =
+    {
+      flake-parts,
+      systems,
+      ...
+    }@inputs:
+    flake-parts.lib.mkFlake { inherit inputs; } {
+      systems = import systems;
+      perSystem =
+        {
+          pkgs,
+          lib,
+          self',
+          ...
+        }:
+        {
+          packages = {
+            stellogen = pkgs.ocamlPackages.callPackage ./package.nix { };
+
+            stellogen-web = (self'.packages.stellogen.override { withExe = false; }).js;
+            stellogen-minimal = self'.packages.stellogen.override {
+              withWeb = false;
+              withDoc = false;
+            };
+
+            docs =
+              (self'.packages.stellogen.override {
+                withExe = false;
+                withWeb = false;
+              }).doc;
+
+            playground = pkgs.stdenvNoCC.mkDerivation {
+              pname = "stellogen-playground";
+              version = "0.1.0";
+              src =
+                let
+                  inherit (lib) fileset;
+                in
+                fileset.toSource {
+                  root = ./.;
+                  fileset = fileset.unions [
+                    ./examples
+                    ./web/build-examples.js
+                    ./web/index.html
+                  ];
+                };
+              buildPhase = ''
+                runHook preBuild
+                node ./web/build-examples.js
+                runHook postBuild
+              '';
+              nativeBuildInputs = [
+                pkgs.nodejs-slim
+              ];
+              installPhase = ''
+                runHook preInstall
+                mkdir -p "$out/share/web/"
+                cp web/index.html web/examples.js  "$out/share/web/"
+                cp ${self'.packages.stellogen-web}/share/web/playground.js "$out/share/web/"
+                runHook postInstall
+              '';
+            };
+
+            default = self'.packages.stellogen;
           };
-          buildInputs = [ ocamlPackages.calendar ];
-        };
 
-        stellogen = ocamlPackages.buildDunePackage {
-          pname = "stellogen";
-          version = "0.1.0";
-          duneVersion = "3";
-          src = ./.;
-          OCAMLPARAM = "_,warn-error=+A"; # Turn all warnings into errors.
-          propagatedBuildInputs = [
-            easy_logging
-          ] ++ (with ocamlPackages; [
-	    calendar
-	    alcotest
-	    base
-	    menhir
-          ]);
-        };
-      in
-      {
-        packages = {
-          inherit stellogen;
-          default = stellogen;
-        };
-        devShells.default = pkgs.mkShell {
-          packages = [
-            pkgs.ocamlPackages.ocaml
-            pkgs.ocamlPackages.ocamlformat
-            pkgs.ocamlPackages.menhir
-            pkgs.ocamlPackages.odoc
-	    pkgs.ocamlPackages.ocaml-lsp
-            pkgs.jq
-          ];
+          apps = {
+            playground.program = pkgs.writeShellApplication {
+              name = "stellogen-playground-server";
+              runtimeInputs = [ pkgs.simple-http-server ];
+              text = ''
+                cd ${lib.escapeShellArg self'.packages.playground}/share/web
+                simple-http-server --index "$@" -- .
+              '';
+            };
+            docs.program = pkgs.writeShellApplication {
+              name = "stellogen-docs-server";
+              runtimeInputs = [ pkgs.simple-http-server ];
+              text = ''
+                cd ${lib.escapeShellArg self'.packages.docs}/share/doc/stellogen/_html
+                simple-http-server --index "$@" -- .
+              '';
+            };
+          };
 
-          inputsFrom = [
-            self.packages.${system}.stellogen
-          ];
+          devShells.default = pkgs.mkShell {
+            packages = [
+              pkgs.jq
+            ]
+            ++ (with pkgs.ocamlPackages; [
+              ocaml
+              ocamlformat
+              menhir
+              odoc
+              ocaml-lsp
+            ]);
+
+            inputsFrom = [
+              self'.packages.stellogen
+            ];
+          };
         };
-      });
+    };
 }

--- a/package.nix
+++ b/package.nix
@@ -1,0 +1,123 @@
+{
+  lib,
+  buildDunePackage,
+
+  alcotest,
+  base,
+  calendar,
+  easy_logging,
+  menhir,
+  menhirLib,
+  ppx_deriving,
+  sedlex,
+  stdio,
+
+  js_of_ocaml,
+  js_of_ocaml-ppx,
+
+  odoc,
+
+  withExe ? true,
+  withWeb ? true,
+  withDoc ? true,
+}:
+assert withExe || withWeb || withDoc;
+buildDunePackage (finalAttrs: {
+  pname = "stellogen";
+  version = "0.1.0";
+  duneVersion = "3";
+  src =
+    let
+      inherit (lib) fileset;
+    in
+    fileset.toSource {
+      root = ./.;
+      fileset = fileset.unions (
+        [
+          ./dune-project
+          ./stellogen.opam
+          ./src
+          ./README.md
+          ./LICENSE
+        ]
+        ++ lib.optional withExe ./bin
+        ++ lib.optional withWeb ./web
+        ++ lib.optionals finalAttrs.doCheck [
+          ./test
+          ./examples
+        ]
+      );
+    };
+
+  outputs = [ "out" ] ++ lib.optional withWeb "js" ++ lib.optional (withExe || withDoc) "doc";
+
+  OCAMLPARAM = "_,warn-error=+A";
+  doCheck = withExe;
+
+  buildFlags =
+    lib.optional finalAttrs.doCheck "@runtest"
+    ++ lib.optional withDoc "@doc"
+    ++ lib.optional withExe "@install"
+    ++ lib.optional withWeb "web/playground.bc.js";
+
+  propagatedBuildInputs = [
+    alcotest
+    base
+    calendar
+    easy_logging
+    menhirLib
+    ppx_deriving
+    sedlex
+    stdio
+  ]
+  ++ lib.optionals withWeb [
+    js_of_ocaml
+    js_of_ocaml-ppx
+  ];
+  nativeBuildInputs = [
+    menhir
+  ]
+  ++ lib.optional withWeb js_of_ocaml
+  ++ lib.optional withDoc odoc;
+
+  buildPhase = ''
+    runHook preBuild
+    dune build -p "$pname" $buildFlags ''${enableParallelBuilding:+-j $NIX_BUILD_CORES}
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+  ''
+  # Documentation is moved from $out to $doc automatically
+  + lib.optionalString withDoc ''
+    mkdir -p "$out/share/doc/"
+    cp -R _build/default/_doc "$out/share/doc/$pname"
+  ''
+  + lib.optionalString withExe ''
+    dune install --prefix $out \
+      --libdir "$OCAMLFIND_DESTDIR" "$pname" \
+      --docdir "$out/share/doc" \
+      --mandir "$out/share/man"
+  ''
+  + lib.optionalString withWeb ''
+    mkdir -p "$js/share/web"
+    cp _build/default/web/playground.bc.js "$js/share/web/playground.js"
+  ''
+  + ''
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Programming language where computation and types are built from the same mechanism: term unification";
+    homepage = "https://github.com/engboris/stellogen";
+    license = lib.licenses.gpl3Only;
+    sourceProvenance = lib.sourceTypes.fromSource;
+    maintainers = [
+      lib.maintainers.magistau
+    ];
+  }
+  // lib.optionalAttrs withExe {
+    mainProgram = "sgen";
+  };
+})

--- a/shell.nix
+++ b/shell.nix
@@ -9,4 +9,4 @@
         or "https://github.com/NixOS/flake-compat/archive/${lock.nodes.${nodeName}.locked.rev}.tar.gz";
     sha256 = lock.nodes.${nodeName}.locked.narHash;
   }
-) { src = ./.; }).defaultNix
+) { src = ./.; }).shellNix

--- a/web/index.html
+++ b/web/index.html
@@ -345,8 +345,8 @@ Term with effect: display terms
         <span id="status"></span>
     </div>
 
-    <script src="playground.js?v=__VERSION__"></script>
-    <script src="examples.js?v=__VERSION__"></script>
+    <script src="playground.js"></script>
+    <script src="examples.js"></script>
     <script>
         const editor = document.getElementById('editor');
         const highlightLayer = document.getElementById('highlight-layer');


### PR DESCRIPTION
- Switched from `flake-utils` to `flake-parts`
- Moved the main derivation to a separate file
- Fixed the derivation so that it builds successfully now
- Refactored the derivation
  - Added arguments: 
    - `withExe` controls compiling the `sgen` executable
    - `withWeb` controls compiling `playground.js`
    - `withDoc` controls running `odoc`
  - Only put relevant files in `src` to reduce rebuilds
  - Added `js` and `doc` outputs
    - Note that with `withExe` disabled, `out` doesn't contain anything of interest.
  - Added metadata
- Added other derivations
  - `stellogen-web` contains `playground.js` and does not attempt to build `sgen`
  - `stellogen-minimal` contains `sgen` and does not attempt to build `playground.js` or OCaml documentation
  - `docs` contains OCaml documentation and does not attempt to build the project
  - `playground` contains files relevant to the web server:
    - `playground.js`
    - `examples.js`
    - `index.html`
- Added apps (can be run with `nix run`)
  - `playground` hosts the playground using [`simple-http-server`](https://github.com/TheWaWaR/simple-http-server), see that project's documentation for accepted flags
  - `docs` hosts the OCaml documentation using the same server
- Updated `default.nix` with `flake-compat` current recommendation
- Added `shell.nix` for non-flake users using `flake-compat`
- Fixed `web/index.html`

Note that OCaml documentation seems to be empty. I don't know OCaml, so I have no idea if this is intended.

Entirely made by a real human with no AI involvement.